### PR TITLE
shortcuts: q to quit and d to return current directory

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -369,6 +369,14 @@ func actionModeGeneral(m *model, msg tea.KeyMsg, esc bool) actionResult {
 			return newActionResult(nil)
 		}
 
+	// Return current directory
+	case key.Matches(msg, keyModeDebug):
+		m.setExit(sanitize.SanitizeOutputPath(m.path))
+		if m.modeSubshell {
+			fmt.Print(m.exitStr)
+		}
+		return newActionResult(tea.Quit)
+
 	// Change modes
 
 	case key.Matches(msg, keyModeHelp):

--- a/keys.go
+++ b/keys.go
@@ -29,7 +29,7 @@ var (
 
 	keyModeDebug  = key.NewBinding(key.WithKeys("d"))
 	keyModeHelp   = key.NewBinding(key.WithKeys("H"))
-	keyModeSearch = key.NewBinding(key.WithKeys("i"))
+	keyModeSearch = key.NewBinding(key.WithKeys("i", "/"))
 
 	keyToggleFollowSymlink = key.NewBinding(key.WithKeys("f"))
 	keyToggleHidden        = key.NewBinding(key.WithKeys("a"))

--- a/keys.go
+++ b/keys.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	keyQuit            = key.NewBinding(key.WithKeys("ctrl+c"))
+	keyQuit            = key.NewBinding(key.WithKeys("ctrl+c", "q"))
 	keyReturnDirectory = key.NewBinding(key.WithKeys("ctrl+d"))
 	keyReturnSelected  = key.NewBinding(key.WithKeys("ctrl+x"))
 


### PR DESCRIPTION
Add vim-inspired key bindings: q, d, /                                                                                                                                               
                                                                                                                                                                                       
  This adds a few additional key bindings for a more familiar navigation experience:                                                                                                   

  - q — quit (same as ctrl+c)
  - d — return current directory and exit (same as ctrl+d); in error state, still toggles debug view
  - / — enter search mode (same as i)

  These are useful when using nav through a shell function like:
  function nv {
      cd "$(nav --pipe "$@")"
  }
